### PR TITLE
Fix showing pdf schedule when network isn't available

### DIFF
--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/network/SchedulePdfLoader.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/network/SchedulePdfLoader.java
@@ -161,7 +161,7 @@ public class SchedulePdfLoader extends BaseDataLoader<Uri, SchedulePdfLoader.Cac
         }
     }
 
-    class CacheInfo implements Serializable {
+    static class CacheInfo implements Serializable {
         private String mForGroup;
         private int mCachedFileSize;
         private byte[] mCachedRangeData = new byte[CHECKED_RANGE_LENGTH];


### PR DESCRIPTION
The class CacheInfo couldn't be persisted, since it had non-serializable implied this$0 member
