### PR TITLE
Always display two-digit minute (e.g. "9:05")

### DIFF
--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/WidgetProvider.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/WidgetProvider.java
@@ -62,7 +62,7 @@ public class WidgetProvider extends AppWidgetProvider {
         if (upcomingHour != null) {
             Timetable.TimeRange time = upcomingHour.getTime();
 
-            views.setTextViewText(R.id.widget_upcoming_hour_time, time.fromHour + ":" + time.fromMinute);
+            views.setTextViewText(R.id.widget_upcoming_hour_time, String.format("%d:%02d", time.fromHour, time.fromMinute));
             views.setTextViewText(R.id.widget_upcoming_hour_title, upcomingHour.getSubjectName());
             views.setTextViewText(R.id.widget_upcoming_hour_room, upcomingHour.getRoom());
 

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/TimetableDayFragment.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/TimetableDayFragment.java
@@ -199,7 +199,7 @@ public class TimetableDayFragment extends Fragment implements BaseDataLoader.Dat
         @Override
         public void onBindViewHolder(VH holder, int position) {
             Timetable.Hour hour = mHoursInDay.get(position);
-            holder.timeTextView.setText(hour.getTime().fromHour + ":" + hour.getTime().fromMinute);
+            holder.timeTextView.setText(String.format("%d:%02d", hour.getTime().fromHour, hour.getTime().fromMinute));
 
 
             String subjectName = hour.getSubjectName();

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/models/Timetable.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/models/Timetable.java
@@ -108,7 +108,7 @@ public class Timetable {
         DateUtils.stripTime(calendar);
 
         for (Day day : mDays) {
-            if (calendar.equals(day.mDate)) {
+            if (calendar.getTimeInMillis() == day.mDate.getTimeInMillis()) {
                 return day;
             }
         }


### PR DESCRIPTION
And without leading zero for hour, as in earlier versions
