### PR TITLE
Show weekend in schedule if we have entries for it

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,9 +50,9 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:23.1.0'
-    compile 'com.android.support:design:23.1.0'
-    compile 'com.android.support:cardview-v7:23.1.0'
-    compile 'com.android.support:recyclerview-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.4.0'
+    compile 'com.android.support:design:23.4.0'
+    compile 'com.android.support:cardview-v7:23.4.0'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
     compile 'com.roomorama:caldroid:2.3.1'
 }

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/AddBusChooseLineFragment.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/AddBusChooseLineFragment.java
@@ -24,6 +24,7 @@ import java.util.List;
 import pl.edu.zut.mad.appwizut2.R;
 import pl.edu.zut.mad.appwizut2.network.BusTimetableLoader;
 import pl.edu.zut.mad.appwizut2.network.HTTPLinks;
+import pl.edu.zut.mad.appwizut2.views.NonShrinkingRecyclerView;
 
 /**
  * Dialog for selecting line to add, will continue to {@link AddBusChooseStopFragment}
@@ -48,7 +49,7 @@ public class AddBusChooseLineFragment extends DialogFragment {
             dismissAllowingStateLoss();
             return null;
         }
-        mRecyclerView = new RecyclerView(getContext());
+        mRecyclerView = new NonShrinkingRecyclerView(getContext());
         mRecyclerView.setLayoutManager(new GridLayoutManager(getContext(), 4));
         mRecyclerView.setAdapter(mAdapter);
         return mRecyclerView;

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/AddBusChooseStopFragment.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/AddBusChooseStopFragment.java
@@ -30,6 +30,7 @@ import pl.edu.zut.mad.appwizut2.network.DataLoadingManager;
 import pl.edu.zut.mad.appwizut2.network.HTTPLinks;
 import pl.edu.zut.mad.appwizut2.utils.MyTextUtils;
 import pl.edu.zut.mad.appwizut2.utils.SelectedBuses;
+import pl.edu.zut.mad.appwizut2.views.NonShrinkingRecyclerView;
 
 /**
  * Dialog for selecting bus stop on line, opened after user chooses line in {@link AddBusChooseLineFragment}
@@ -58,7 +59,7 @@ public class AddBusChooseStopFragment extends DialogFragment {
             dismissAllowingStateLoss();
             return null;
         }
-        mRecyclerView = new RecyclerView(getContext());
+        mRecyclerView = new NonShrinkingRecyclerView(getContext());
         mRecyclerView.setLayoutManager(new LinearLayoutManager(getContext()));
         mRecyclerView.setAdapter(mAdapter);
         return mRecyclerView;

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/TimetableDayFragment.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/fragments/TimetableDayFragment.java
@@ -13,10 +13,8 @@ import android.widget.Button;
 import android.widget.TextView;
 
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.List;
 
 import pl.edu.zut.mad.appwizut2.R;
@@ -26,7 +24,6 @@ import pl.edu.zut.mad.appwizut2.network.BaseDataLoader;
 import pl.edu.zut.mad.appwizut2.network.DataLoadingManager;
 import pl.edu.zut.mad.appwizut2.network.ScheduleCommonLoader;
 import pl.edu.zut.mad.appwizut2.utils.Constants;
-import pl.edu.zut.mad.appwizut2.utils.DateUtils;
 
 /**
  * Schedule for a particular day
@@ -64,6 +61,15 @@ public class TimetableDayFragment extends Fragment implements BaseDataLoader.Dat
         outState.putLong(Constants.ARG_DATE, mDate.getTime());
     }
 
+    @Override
+    public void setUserVisibleHint(boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+        if (isVisibleToUser) {
+            // TODO: Show this in UI?
+            Log.v(TAG, "Showing schedule for day: " + Constants.FORMATTER.format(mDate));
+        }
+    }
+
     private void putDataInView() {
         if (mTimetable == null) {
             return;
@@ -75,8 +81,6 @@ public class TimetableDayFragment extends Fragment implements BaseDataLoader.Dat
             mHoursInDay = Collections.emptyList();
             mNoClassesMessage.setVisibility(View.VISIBLE);
         } else {
-            // TODO: Show this in UI?
-            Log.v(TAG, "About to display schedule for day: " + Constants.FORMATTER.format(mDate));
             mHoursInDay = Arrays.asList(scheduleDay.getTasks());
             mNoClassesMessage.setVisibility(View.GONE);
         }
@@ -132,33 +136,6 @@ public class TimetableDayFragment extends Fragment implements BaseDataLoader.Dat
         TimetableDayFragment fragment = new TimetableDayFragment();
         fragment.setArguments(args);
         return fragment;
-    }
-
-    /**
-     * Create instance of this fragment to show schedule for specified day of week
-     */
-    public static TimetableDayFragment newInstance(int dayOfWeek) {
-        GregorianCalendar calendar = new GregorianCalendar();
-        DateUtils.stripTime(calendar);
-
-        int todayWeekDay = calendar.get(Calendar.DAY_OF_WEEK);
-
-        // Rewind calendar to last monday
-        int daysFromMonday = todayWeekDay - Calendar.MONDAY;
-        if (daysFromMonday < 0) {
-            daysFromMonday += 7;
-        }
-        calendar.add(Calendar.DATE, -daysFromMonday);
-
-        // If we're in weekend skip to next week
-        if (todayWeekDay == Calendar.SATURDAY || todayWeekDay == Calendar.SUNDAY) {
-            calendar.add(Calendar.DATE, 7);
-        }
-
-        // Now move forward to requested day
-        calendar.add(Calendar.DATE, dayOfWeek - Calendar.MONDAY);
-
-        return newInstance(calendar.getTime());
     }
 
     @Override

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/views/NonShrinkingRecyclerView.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/views/NonShrinkingRecyclerView.java
@@ -1,0 +1,30 @@
+package pl.edu.zut.mad.appwizut2.views;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import android.support.v7.widget.RecyclerView;
+import android.util.AttributeSet;
+
+/**
+ * RecyclerView variant that will never report AT_MOST widthSpec
+ *
+ * Used to work-around bug in RecyclerView when used in Dialog
+ */
+public class NonShrinkingRecyclerView extends RecyclerView {
+    public NonShrinkingRecyclerView(Context context) {
+        this(context, null);
+    }
+
+    public NonShrinkingRecyclerView(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onMeasure(int widthSpec, int heightSpec) {
+        super.onMeasure(
+                widthSpec,
+                //MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthSpec), MeasureSpec.EXACTLY),
+                heightSpec
+        );
+    }
+}

--- a/app/src/main/java/pl/edu/zut/mad/appwizut2/views/NonShrinkingRecyclerView.java
+++ b/app/src/main/java/pl/edu/zut/mad/appwizut2/views/NonShrinkingRecyclerView.java
@@ -22,8 +22,7 @@ public class NonShrinkingRecyclerView extends RecyclerView {
     @Override
     protected void onMeasure(int widthSpec, int heightSpec) {
         super.onMeasure(
-                widthSpec,
-                //MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthSpec), MeasureSpec.EXACTLY),
+                MeasureSpec.makeMeasureSpec(MeasureSpec.getSize(widthSpec), MeasureSpec.EXACTLY),
                 heightSpec
         );
     }

--- a/app/src/main/res/layout/card_item.xml
+++ b/app/src/main/res/layout/card_item.xml
@@ -5,15 +5,15 @@ xmlns:card_view="http://schemas.android.com/apk/res-auto"
 xmlns:android="http://schemas.android.com/apk/res/android"
 android:id="@+id/card_view"
 android:layout_width="match_parent"
-android:layout_height="match_parent"
+android:layout_height="wrap_content"
 card_view:cardCornerRadius="5dp"
-android:layout_margin="5dp">
+android:layout_margin="5dp"
+android:background="@color/white">
 
 <RelativeLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:id="@+id/cardItemView"
-    android:background="@color/white">
+    android:layout_height="wrap_content"
+    android:id="@+id/cardItemView">
 
     <RelativeLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -37,6 +37,8 @@
         <item>ŚR</item>
         <item>CZW</item>
         <item>PT</item>
+        <item>SOB</item>
+        <item>NIEDZ</item>
     </string-array>
     <string name="timetable_unavailable">Nie możemy pokazać tego planu w aplikacji</string>
     <string name="timetable_not_configured">Nie wybrałeś żadnej grupy</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -32,6 +32,9 @@
         <item>Çar</item>
         <item>Per</item>
         <item>Cum</item>
+        <!-- TODO: Review and shorten, these two are from Google Translate -->
+        <item>Cumartesi</item>
+        <item>Pazar</item>
     </string-array>
     <string name="timetable_unavailable">Görüntülenemiyor takvimi app</string>
     <string name="timetable_not_configured">Hiçbir grup</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,8 @@
         <item>WED</item>
         <item>THU</item>
         <item>FRI</item>
+        <item>SAT</item>
+        <item>SUN</item>
     </string-array>
     <string name="timetable_unavailable">Cannot display the schedule in the app</string>
     <string name="timetable_not_configured">You have not chosen a group</string>


### PR DESCRIPTION
Now TimetableFragment can present tabs as Mon-Fri (as before), Sat-Sun and Mon-Sun, depending on available days in schedule

Tested with manually modified timetable as we don't have test accounts yet, assuming non-stationary students are imported correctly this should work ok.

It was necessary to update support library in order to dynamically change available tabs, so this might need some testing, I've already fixed one incompatibility with support library in `card_item.xml` (which is used for Announcements/Changes in schedule)
